### PR TITLE
Added '+' prefix option to capitalize the words

### DIFF
--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -12,7 +12,12 @@ const Gtk = imports.gi.Gtk;
 /// @return {string} Datetime representation of format, or format if the conversion fails, or datetime representation of defaultFormat, or blank.
 ///
 function dateTimeFormat(format, defaultFormat) {
-	return (format && new Date().toLocaleFormat(format) || format) || defaultFormat && new Date().toLocaleFormat(defaultFormat) || "";
+	var dtf = (format && new Date().toLocaleFormat(format) || format) || defaultFormat && new Date().toLocaleFormat(defaultFormat) || "";
+	// Capitalizes the words prefixed by + sign
+	dtf = dtf.replace(/(\+\b\w)/gi, function(m) {
+		return m.toUpperCase().replace("+", "");
+	});
+	return dtf;	
 }
 
 ///

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -104,6 +104,12 @@
 				["1, 2, ...", "An optional decimal width specifier may follow the (possibly absent) flag.  If the natural size of the field is smaller than this width, then the result string is padded (on the left) to the specified width."],
 				["E, O", "Some conversion specifications can be modified by preceding the conversion specifier character by the E or O modifier to indicate that an alternative format should be used.  If the alternative format or specification does not exist for the current locale, the behavior will be as if the unmodified conversion specification were used.\nThe Single UNIX Specification mentions %Ec, %EC, %Ex, %EX, %Ey, %EY, %Od, %Oe, %OH, %OI, %Om, %OM, %OS, %Ou, %OU, %OV, %Ow, %OW, %Oy, where the effect of the O modifier is to use alternative numeric symbols (say, roman numerals), and that of the E modifier is to use a locale-dependent alternative representation."]
 			]
+		},
+		{
+			"label": "Other Options",
+			"content": [
+				["+", "Prefix the '%' character with a '+' sign to capitalize the next word."]
+			]
 		}
 	]
 }


### PR DESCRIPTION
Hi,

In my locale the days and months name are all lowercase. But I prefer capitalized ones. I added a simple '+' sign prefix as format option.
With this patch you can use, for example, **+%A** to get the day name with the first letter uppercase.

Cheers,
 Luca