### PR TITLE
Unicode support in format strings

### DIFF
--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -5,6 +5,26 @@
 const Gtk = imports.gi.Gtk;
 
 ///
+/// Convert unicode characters in a string to escaped ascii.
+///
+/// @param {string} string - The string to be escaped.
+/// @return {string} The string with all unicode characters replaced by escaped ascii.
+function escapeUnicode(string) {
+	return string.replace(/[^\0-~]/g, function(ch) {
+		return "\\u" + ("0000" + ch.charCodeAt().toString(16)).slice(-4);
+	});
+}
+
+///
+/// Safe-esacpe characters in a string for parsing with JSON.parse, including unicode and special characters.
+///
+/// @param {string} string - The string to be escaped.
+/// @return {string} The string with problematic characters escaped.
+function escapeJson(string) {
+	return escapeUnicode(string.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"'));
+}
+
+///
 /// Convert string to datetime format.
 ///
 /// @param {string} format - Format to convert into a datetime string.
@@ -12,13 +32,7 @@ const Gtk = imports.gi.Gtk;
 /// @return {string} Datetime representation of format, or format if the conversion fails, or datetime representation of defaultFormat, or blank.
 ///
 function dateTimeFormat(format, defaultFormat) {
-	function escapeUnicode(str) {
-		return str.replace(/[^\0-~]/g, function(ch) {
-			return "\\u" + ("0000" + ch.charCodeAt().toString(16)).slice(-4);
-		});
-	}
-
-	return JSON.parse('"' + escapeUnicode((format && new Date().toLocaleFormat(escapeUnicode(format)) || format) || defaultFormat && new Date().toLocaleFormat(escapeUnicode(defaultFormat)) || "").replace('"',     '\\"') + '"');
+	return JSON.parse('"' + escapeUnicode(format && new Date().toLocaleFormat(escapeJson(format)) || defaultFormat && new Date().toLocaleFormat(escapeJson(defaultFormat)) || "") + '"');
 }
 
 ///

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -12,7 +12,13 @@ const Gtk = imports.gi.Gtk;
 /// @return {string} Datetime representation of format, or format if the conversion fails, or datetime representation of defaultFormat, or blank.
 ///
 function dateTimeFormat(format, defaultFormat) {
-	return (format && new Date().toLocaleFormat(format) || format) || defaultFormat && new Date().toLocaleFormat(defaultFormat) || "";
+	function escapeUnicode(str) {
+		return str.replace(/[^\0-~]/g, function(ch) {
+			return "\\u" + ("0000" + ch.charCodeAt().toString(16)).slice(-4);
+		});
+	}
+
+	return JSON.parse('"' + escapeUnicode((format && new Date().toLocaleFormat(escapeUnicode(format)) || format) || defaultFormat && new Date().toLocaleFormat(escapeUnicode(defaultFormat)) || "").replace('"',     '\\"') + '"');
 }
 
 ///


### PR DESCRIPTION
This change fixes an issue where the Datetime Format GUI fails to load with the error 'Failed to convert locale string to UTF8: Invalid byte sequence in conversion input' if unicode characters are entered in any of the format strings.

Date().toLocaleFormat(format) only accepts ascii characters in the format string. This change works around that limitation by escaping non-ascii characters in the format string before passing the string to toLocaleFormat(), then escaping the result in case non-ascii characters are in the localized string, and finally unescaping the resulting string by passing it to JSON.parse.